### PR TITLE
Implement React admin dashboard

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -23,13 +23,15 @@ add_action('wp_footer',  'showfooter');
 /* end */
 /*dd code*/
 add_action("admin_menu", "csm_admin_menu");
+add_action('admin_enqueue_scripts', 'csm_enqueue_admin_assets');
+add_action('rest_api_init', 'csm_register_rest');
   
 /**
  * This is an example function
 
  * @return void
  */
-function csm_admin_menu() 
+function csm_admin_menu()
 {
     add_submenu_page(
         'options-general.php',
@@ -101,8 +103,8 @@ function showfooter()
  * @since  1.0.0
  * @return void
  */
-function register_csm_settings() 
-{ 
+function register_csm_settings()
+{
     register_setting('csm-settings', 'csm_show_page'); register_setting('csm-settings', 'csm_mode');   
     register_setting('csm-settings', 'csm_who_can_access');
     register_setting('csm-settings', 'csm_roles');
@@ -114,6 +116,70 @@ function register_csm_settings()
     register_setting('csm-settings', 'csm_page');
 }
 
+function csm_enqueue_admin_assets($hook)
+{
+    if ('settings_page_csm-settings' !== $hook) {
+        return;
+    }
+
+    wp_enqueue_script(
+        'csm-admin-dashboard',
+        plugin_dir_url(__FILE__) . 'js/admin-dashboard.js',
+        array('wp-element', 'wp-components', 'wp-api-fetch'),
+        '1.0.0',
+        true
+    );
+
+    $settings = array(
+        'csm_mode'          => get_option('csm_mode', 'live'),
+        'csm_show_page'     => get_option('csm_show_page'),
+        'csm_page'          => (array) get_option('csm_page'),
+        'csm_who_can_access'=> get_option('csm_who_can_access', 'logged'),
+        'csm_roles'         => (array) get_option('csm_roles'),
+        'dis_header'        => get_option('dis_header'),
+        'dis_footer'        => get_option('dis_footer'),
+        'dis_sidebar'       => get_option('dis_sidebar'),
+        'csm_appearance'    => get_option('csm_appearance'),
+        'roles'             => wp_roles()->roles,
+        'pages'             => get_pages(array('post_status' => 'publish')),
+        'nonce'             => wp_create_nonce('csm_save_settings'),
+    );
+
+    wp_localize_script('csm-admin-dashboard', 'csmSettings', $settings);
+}
+
+function csm_register_rest()
+{
+    register_rest_route(
+        'csm/v1',
+        '/settings',
+        array(
+            'methods'  => 'POST',
+            'callback' => 'csm_save_settings',
+            'permission_callback' => function () {
+                return current_user_can('manage_options');
+            },
+        )
+    );
+}
+
+function csm_save_settings($request)
+{
+    $params = $request->get_json_params();
+
+    update_option('csm_mode', sanitize_text_field($params['csm_mode']));
+    update_option('csm_show_page', intval($params['csm_show_page']));
+    update_option('csm_page', array_map('intval', (array) $params['csm_page']));
+    update_option('csm_who_can_access', sanitize_text_field($params['csm_who_can_access']));
+    update_option('csm_roles', array_map('sanitize_text_field', (array) $params['csm_roles']));
+    update_option('csm_appearance', sanitize_text_field($params['csm_appearance']));
+    update_option('dis_header', sanitize_text_field($params['dis_header']));
+    update_option('dis_footer', sanitize_text_field($params['dis_footer']));
+    update_option('dis_sidebar', sanitize_text_field($params['dis_sidebar']));
+
+    return array('success' => true);
+}
+
 /**
  * Define constants
  *
@@ -122,223 +188,11 @@ function register_csm_settings()
  */
 function csm_settings()
 {
-    global $wpdb;
-    $pages = $wpdb->get_results("Select ID, post_title from {$wpdb->posts} where post_type = 'page' and post_status = 'publish'");
     ?>
-    <div class="wrap"><h2><?php _e('Coming Soon Mode By Spectra', 'obwoos'); ?>
-</h2> 
-</div>
     <div class="wrap">
-        <div class="postbox">
-            <div class="error-msg"><?php //settings_errors(); ?></div>
-            <div class="inside"> 
-                <form method="post" action="options.php" class="csm-option-form">
-                    <?php settings_fields('csm-settings'); ?>
-                    <?php do_settings_sections('csm-settings'); ?>
-                    <table class="form-table">
-                        <tr valign="top">
-                            <th scope="row"><?php _e('Select Mode', 'csm'); ?></th>
-                            <td>       
-                                <?php 
-                                $csm_mode = get_option('csm_mode', 'live');                   
-                                ?> 
-                                <label><input type="radio" name="csm_mode" value="live" <?php echo $csm_mode == 'live' ? 'checked':''; ?> /> <?php _e('Live', 'csm')?>
-                                <p  class="description">If Live is selected then a website is visible for all. </p>
-                                </label><br />
-                               <!-- <label><input type="radio" name="csm_mode" value="maintainance" <?php echo $csm_mode == 'maintainance' ? 'checked':''; ?> /> <?php _e('Maintainance', 'csm')?></label><br />-->
-                                <label><input type="radio" name="csm_mode" value="comming-soon" <?php echo $csm_mode == 'comming-soon' ? 'checked':''; ?> /> <?php _e('Coming Soon', 'csm')?>
-                                <p  class="description">If Coming Soon is selected then the site visitors will redirect to the dedicated page.</p>
-                                </label><br />
-                            </td>
-                        </tr>
-                        <tr valign="top" class="csm-choose-page" style="display:<?php echo $csm_mode == 'live' ? 'none' : 'table-row'; ?>">
-                            <th scope="row"><?php _e('Select Page', 'csm'); ?></th>
-                            <td>  
-                                 
-                            <?php 
-                                    
-                            $dropdown_args = array(
-                                'post_type'        => 'page', 
-                                'selected'         => get_option('csm_show_page'),
-                                'name'             => 'csm_show_page', 
-                            );
-                            wp_dropdown_pages($dropdown_args);  
-                            ?> 
-                            <p class="description">The site visitors will be redirected to the selected page if Coming Soon mode is active.</p>
-                            </td>
-                        </tr>
-                        <tr valign="top" class="csm-choose-page" style="display:<?php echo $csm_mode == 'live' ? 'none' : 'table-row'; ?>">
-                            <th scope="row"><?php _e('Exclude pages', 'csm'); ?></th>
-                            <td>  
-                                 
-                            <select multiple="multiple" id="csm_page" name="csm_page[]">
-                                <?php //echo esc_attr( __( 'Select page' ) ); ?></option> 
-                                <?php 
-                                
-                                //$selected=array();
-                                $selected=(array) get_option('csm_show_page');
-                                $selected1=(array)get_option('csm_page');$f=array_merge($selected, $selected1);
-
-                                $pages1 = get_pages(); 
-                                
-                                foreach ( $pages1 as $page ) {
-                                    ?>
-                                <option <?php if(in_array($page->ID, $f) ) {?> selected="selected" <?php } ?>
-                                value=" <?php echo $page->ID; ?>"><?php echo $page->post_title;
-                                ?></option>
-                                <?php } ?>
-                                </select>
-                                <p class="description">The site visitors will be able to access selected page even Coming Soon mode is active.</p>
-                            </td>
-                        </tr>
-                        <tr valign="top" class="csm-who-can-access" style="display:<?php echo $csm_mode == 'live' ? 'none' : 'table-row'; ?>">
-                            <th scope="row"><?php _e('Live Site Access', 'csm'); ?></th>
-                            <td>   
-                            <?php 
-                                $csm_who_can_access = get_option('csm_who_can_access', 'logged');
-                                                     
-                            ?> 
-                                <label><input type="radio" name="csm_who_can_access" value="logged" <?php echo $csm_who_can_access == 'logged' ? 'checked':''; ?> /> <?php _e('All logged-in users', 'csm')?></label><br /><p></p>
-                                <label><input type="radio" name="csm_who_can_access" value="custom" <?php echo $csm_who_can_access == 'custom' ? 'checked':''; ?> /> <?php _e('Custom', 'csm')?></label><br /> 									
-                                <div style="margin-left: 30px;margin-top: 10px;display:<?php echo $csm_who_can_access == 'logged' ? 'none' : 'block' ?>" class="csm-custom-roles">
-                                <?php
-                                global $wp_roles;
-                                $roles = $wp_roles->roles; 
-                                $csm_roles = is_array(get_option('csm_roles')) ? get_option('csm_roles') : array(); 
-                                foreach($roles as $role => $role_info){
-                                    echo '<label><input type="checkbox" name="csm_roles[]" value="'.$role.'"'. ( in_array($role, $csm_roles) ? 'checked':'' ). ' /> '.$role_info['name'].'</label><br />';
-                                }
-                                ?>
-                                </div>
-                                <p  class="description">Select the users who can access the live site even Coming Soon mode is activated.</p>
-                            </td>
-                        </tr>
-
-                      
-<tr class="theme-compatibility" style="display:<?php echo $csm_mode == 'live' ? 'none' : 'table-row'; ?>">
-<th scope="row">Page Appearance</th><td>
-
-    <?php 
-    $loadonly_content = get_option('csm_appearance');
-    ?>
-    
-    <label><input type="radio" class="dis_more_option" name="csm_appearance" value="loadonly_content" <?php echo $loadonly_content == 'loadonly_content' ? 'checked':''; ?> /> 
-    <?php _e('Display Page Content Only', 'csm')?></label><br 
-    ><p></p>
-    <label><input type="radio" class="dis_more_option" name="csm_appearance" value="dis_more_option" 
-    <?php echo $loadonly_content == 'dis_more_option' ? 'checked':''; ?> /> <?php _e('More Custom Options', 'csm')?></label>									
-    <div class="chk_con" style="margin-left: 30px;margin-top: 10px;">
-    <!--<label for="">
-        <input <?php if (get_option('loadonly_content')) {
-            echo 'checked="checked"';
-            } 
-                ?> name="loadonly_content"  type="checkbox" />
-                <?php _e('Display Page Content Only', 'csm'); ?></label>
-<br />
-<p></p>
-<label for="">
-<input class="dis_more_option" <?php if (get_option('dis_more_option')) {
-    echo 'checked="checked"';
-                               } ?> 
-                               name="dis_more_option" value="chk_con"  type="checkbox" />
-    <?php _e('More Custom Options', 'csm'); ?></label>-->                            
-
-
-<label class="chk_con" for="">
-    <input <?php if (get_option('dis_header')) {
-        echo 'checked="checked"';
-        } ?> name="dis_header"  type="checkbox" />
-    <?php _e('Disable Header', 'csm'); ?></label>                            
-<br />   
-
-<label class="chk_con" for=""><input <?php if (get_option('dis_footer')) {
-    echo 'checked="checked"';
-                                     } ?> 
-                                     name="dis_footer"  type="checkbox" />
-    <?php _e('Disable Footer', 'csm'); ?></label>                            
-    <br />
-    <label class="chk_con" for="">
-    <input <?php if (get_option('dis_sidebar')) {
-            echo 'checked="checked"';
-            } ?> name="dis_sidebar"  type="checkbox" />
-            <?php _e('Disable Sidebar', 'csm'); ?></label>
-        </div>	
-        <p  class="description">Make the selected page more interactive by controlling the website components.</p>
-    </td>
-</tr>
-</tbody>
-</table>
-
-                    </table>
-                    
-                    <?php submit_button(); ?>
-                
-                </form>
-            </div>
-        </div>
+        <div id="csm-admin-app"></div>
     </div>
-    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
-<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
-<script src="<?php echo plugin_dir_url( __FILE__ ) . 'js/custom.js'?>"></script>
-<link href="<?php echo plugin_dir_url( __FILE__ ) . 'css/admin.css'?>" rel="stylesheet" />
-<!--<script>
-
-        jQuery(document).ready(function(){
-            if(jQuery('input[name="csm_appearance"]').prop('checked') == true){
-                var inputValue1 = jQuery('input[name="csm_appearance"]').attr("value");
-                if(inputValue1 == 'dis_more_option'){
-                    jQuery(".chk_con").show();
-                
-                }else{
-                    jQuery('.chk_con').hide();
-                }
-            }
-            jQuery('input[name="csm_appearance"]').click(function(){
-                var inputValue = jQuery(this).attr("value");
-                if(inputValue == 'dis_more_option'){
-                    jQuery(".chk_con").show();
-                }else{
-                    jQuery(".chk_con").hide();
-                }
-            });
-            jQuery('input[name="csm_mode"]').change(function(){
-                let mode = jQuery(this).val();
-                 
-                if(mode == 'live'){
-                    jQuery('.csm-choose-page').hide();
-                    jQuery('.csm-who-can-access').hide();
-                    jQuery('.theme-compatibility').hide();
-                }
-                else{
-                    jQuery('.csm-choose-page').css('display','table-row');
-                    jQuery('.csm-who-can-access').css('display','table-row');
-                    jQuery('.theme-compatibility').css('display','table-row');
-                }
-            })
-        })
-        jQuery(document).ready(function(){
-            jQuery('input[name="csm_who_can_access"]').change(function(){
-                let csm_who_can_access = jQuery(this).val();
-                 
-                if(csm_who_can_access == 'logged'){
-                    jQuery('.csm-custom-roles').hide();
-                }
-                else{
-                    jQuery('.csm-custom-roles').show();
-                }
-            })
-        })
-        // In your Javascript (external .js resource or <script> tag)
-jQuery(document).ready(function() {
-    jQuery('#csm_show_page').select2();
-    jQuery('#csm_page').select2();
-    jQuery('.select2').css('width','200px');
-});
-
-    </script>-->
-
-  
-<?php
+    <?php
 }
  
 /**

--- a/js/admin-dashboard.js
+++ b/js/admin-dashboard.js
@@ -1,0 +1,125 @@
+const { useState, useEffect } = wp.element;
+const { Button, SelectControl, RadioControl, CheckboxControl, PanelBody, PanelRow } = wp.components;
+
+function App() {
+    const pages = csmSettings.pages.map( p => ( { label: p.post_title, value: parseInt(p.ID) } ) );
+    const roles = Object.entries( csmSettings.roles ).map( ( [ slug, data ] ) => ( { label: data.name, value: slug } ) );
+
+    const [mode, setMode] = useState( csmSettings.csm_mode );
+    const [showPage, setShowPage] = useState( parseInt(csmSettings.csm_show_page) || 0 );
+    const [excludePages, setExcludePages] = useState( csmSettings.csm_page || [] );
+    const [whoCanAccess, setWhoCanAccess] = useState( csmSettings.csm_who_can_access );
+    const [roleValues, setRoleValues] = useState( csmSettings.csm_roles || [] );
+    const [appearance, setAppearance] = useState( csmSettings.csm_appearance || 'loadonly_content' );
+    const [disableHeader, setDisableHeader] = useState( !!csmSettings.dis_header );
+    const [disableFooter, setDisableFooter] = useState( !!csmSettings.dis_footer );
+    const [disableSidebar, setDisableSidebar] = useState( !!csmSettings.dis_sidebar );
+
+    const saveSettings = () => {
+        wp.apiFetch( {
+            path: '/csm/v1/settings',
+            method: 'POST',
+            data: {
+                nonce: csmSettings.nonce,
+                csm_mode: mode,
+                csm_show_page: showPage,
+                csm_page: excludePages,
+                csm_who_can_access: whoCanAccess,
+                csm_roles: roleValues,
+                csm_appearance: appearance,
+                dis_header: disableHeader ? 'on' : '',
+                dis_footer: disableFooter ? 'on' : '',
+                dis_sidebar: disableSidebar ? 'on' : ''
+            }
+        } ).then( () => {
+            alert( 'Settings saved' );
+        } ).catch( () => {
+            alert( 'Error saving settings' );
+        } );
+    };
+
+    return wp.element.createElement('div', { className: 'csm-react-admin' },
+        wp.element.createElement('h2', null, 'Coming Soon Mode By Spectra'),
+        wp.element.createElement('div', { className: 'csm-control-group' },
+            wp.element.createElement( RadioControl, {
+                label: 'Select Mode',
+                selected: mode,
+                options: [
+                    { label: 'Live', value: 'live' },
+                    { label: 'Coming Soon', value: 'comming-soon' }
+                ],
+                onChange: setMode
+            } ),
+            mode !== 'live' && wp.element.createElement( SelectControl, {
+                label: 'Select Page',
+                value: showPage,
+                options: [ { label: 'Select page', value: 0 }, ...pages ],
+                onChange: ( val ) => setShowPage( parseInt( val ) )
+            } ),
+            mode !== 'live' && wp.element.createElement( SelectControl, {
+                multiple: true,
+                label: 'Exclude pages',
+                value: excludePages,
+                options: pages,
+                onChange: ( val ) => setExcludePages( Array.isArray( val ) ? val : [ val ] )
+            } ),
+            mode !== 'live' && wp.element.createElement( RadioControl, {
+                label: 'Live Site Access',
+                selected: whoCanAccess,
+                options: [
+                    { label: 'All logged-in users', value: 'logged' },
+                    { label: 'Custom', value: 'custom' }
+                ],
+                onChange: setWhoCanAccess
+            } ),
+            mode !== 'live' && whoCanAccess === 'custom' && wp.element.createElement( 'div', {},
+                roles.map( role => (
+                    wp.element.createElement( CheckboxControl, {
+                        key: role.value,
+                        label: role.label,
+                        checked: roleValues.includes( role.value ),
+                        onChange: ( checked ) => {
+                            if ( checked ) {
+                                setRoleValues( [ ...roleValues, role.value ] );
+                            } else {
+                                setRoleValues( roleValues.filter( r => r !== role.value ) );
+                            }
+                        }
+                    } )
+                ) )
+            ),
+            mode !== 'live' && wp.element.createElement( RadioControl, {
+                label: 'Page Appearance',
+                selected: appearance,
+                options: [
+                    { label: 'Display Page Content Only', value: 'loadonly_content' },
+                    { label: 'More Custom Options', value: 'dis_more_option' }
+                ],
+                onChange: setAppearance
+            } ),
+            appearance === 'dis_more_option' && wp.element.createElement( 'div', {},
+                wp.element.createElement( CheckboxControl, {
+                    label: 'Disable Header',
+                    checked: disableHeader,
+                    onChange: setDisableHeader
+                } ),
+                wp.element.createElement( CheckboxControl, {
+                    label: 'Disable Footer',
+                    checked: disableFooter,
+                    onChange: setDisableFooter
+                } ),
+                wp.element.createElement( CheckboxControl, {
+                    label: 'Disable Sidebar',
+                    checked: disableSidebar,
+                    onChange: setDisableSidebar
+                } )
+            )
+        ),
+        wp.element.createElement( Button, { isPrimary: true, onClick: saveSettings }, 'Save Settings' )
+    );
+}
+
+wp.element.addFilter ? null : null; // placeholder to ensure script loaded after wp.element
+wp.domReady( function() {
+    wp.element.render( wp.element.createElement( App ), document.getElementById( 'csm-admin-app' ) );
+} );


### PR DESCRIPTION
## Summary
- add React-powered admin dashboard script
- replace old PHP settings page with React mount point
- expose REST endpoint and enqueue React assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6840584a66688327b3eb1ae6a0b46500